### PR TITLE
Add git and ca-certificates packages to the apt-get install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER yigal@publysher.nl
 
 # Install pygments (for syntax highlighting) 
 RUN apt-get -qq update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends python-pygments git \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends python-pygments git ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download and install hugo

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER yigal@publysher.nl
 
 # Install pygments (for syntax highlighting) 
 RUN apt-get -qq update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends python-pygments \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends python-pygments git \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download and install hugo

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Images derived from this image can either run as a stand-alone server, or functi
 
 Prerequisites
 -------------
+
 The image is based on the following directory structure:
 
 	.
@@ -27,6 +28,7 @@ In other words, your Hugo site resides in the `site` directory, and you have a s
 
 Building your site
 ------------------
+
 Based on this structure, you can easily build an image for your site:
 
 	docker build -t my/image .
@@ -36,6 +38,7 @@ Your site is automatically generated during this build.
 
 Using your site
 ---------------
+
 There are two options for using the image you generated: 
 
 - as a stand-alone image
@@ -59,4 +62,5 @@ The image is also suitable for use as a volume image for a web server, such as [
 
 Examples
 --------
+
 For an example of a Hugo site, have a look at https://github.com/publysher/blog.publysher.nl

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Images derived from this image can either run as a stand-alone server, or functi
 
 Prerequisites
 -------------
-
 The image is based on the following directory structure:
 
 	.
@@ -28,7 +27,6 @@ In other words, your Hugo site resides in the `site` directory, and you have a s
 
 Building your site
 ------------------
-
 Based on this structure, you can easily build an image for your site:
 
 	docker build -t my/image .
@@ -38,7 +36,6 @@ Your site is automatically generated during this build.
 
 Using your site
 ---------------
-
 There are two options for using the image you generated: 
 
 - as a stand-alone image
@@ -62,5 +59,4 @@ The image is also suitable for use as a volume image for a web server, such as [
 
 Examples
 --------
-
 For an example of a Hugo site, have a look at https://github.com/publysher/blog.publysher.nl


### PR DESCRIPTION
In order to be able to pull git submodules using `https` I've added git & ca-certificates to installed packages. Also, there's one unnecessary commit with editions to README (it doesn't affect its looking at all).
