### PR TITLE
Added pip so that Pygments could be updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ MAINTAINER yigal@publysher.nl
 
 # Install pygments (for syntax highlighting) 
 RUN apt-get -qq update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends python-pygments git ca-certificates \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends python-pip git ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN pip install Pygments --upgrade
 
 # Download and install hugo
 ENV HUGO_VERSION 0.16


### PR DESCRIPTION
The pygments version in the apt get repo is very old so to get
a newer version one has to use pip. Not sure if this would break
other functionality though, I'm just using it for building and not
as a server.
