### PR TITLE
Update HUGO_BINARY naming to new release format.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get -qq update \
 
 # Download and install hugo
 ENV HUGO_VERSION 0.20.6
-ENV HUGO_BINARY hugo_${HUGO_VERSION}-64bit.deb
+ENV HUGO_BINARY hugo_${HUGO_VERSION}_Linux-64bit.deb
+
 
 ADD https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /tmp/hugo.deb
 RUN dpkg -i /tmp/hugo.deb \


### PR DESCRIPTION
Hugo releases changed format with 20.6, changes it to match the new format.
[Succesful build](https://hub.docker.com/r/erothejoker/docker-hugo/builds/bnvim9dtpqty4au4k5sbbb4/)