### PR TITLE
Update to Jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER yigal@publysher.nl
 
 # Install pygments (for syntax highlighting) 


### PR DESCRIPTION
I needed to base off [Jessie](https://www.debian.org/releases/jessie/) to install the [Firebase Tools](https://www.npmjs.com/package/firebase-cli), which in turn require Node. [Node](https://nodejs.org/en/download/package-manager/) no longer support Wheezy.